### PR TITLE
add version api methods and bump version to 0.1.9-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject intermine/imcljs "0.1.8-SNAPSHOT"
+(defproject intermine/imcljs "0.1.9-SNAPSHOT"
   :description "imcljs"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/imcljs/fetch.cljs
+++ b/src/imcljs/fetch.cljs
@@ -58,9 +58,12 @@
   [service & [options]]
   (restful :post "/list/enrichment" service (merge imcljs.internal.defaults/default-enrichment options)))
 
+; Versions
 
+(defn version-release
+  [service]
+  (restful :get "/version/release" service {:format "text"}))
 
-
-
-
-
+(defn version-intermine
+  [service]
+  (restful :get "/version/intermine" service {:format "text"}))


### PR DESCRIPTION
low urgency; I won't be actually *using* this right now, as discussed offline.