### PR TITLE
add custom format endpoint for csv, tsv

### DIFF
--- a/src/imcljs/fetch.cljs
+++ b/src/imcljs/fetch.cljs
@@ -20,6 +20,11 @@
   [service query & [options]]
   (restful :post "/query/results/fasta" service (merge {:query query} options)))
 
+(defn fetch-custom-format
+  ;;e.g. csv, tsv formats.
+  [service query & [options]]
+  (restful :post "/query/results" service (merge {:query query} options)))
+
 (defn records
   [service query & [options]]
   (restful :post "/query/results" service (merge {:query query :format "jsonobjects"} options)))


### PR DESCRIPTION
'nuff said, really. creating separate endpoints for these two similar formats doesn't make a lot of sense & would result in more complex code to call the methods