### PR TITLE
Move io (http) functions to their own clj/cljs namespaces

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject intermine/imcljs "0.1.26"
+(defproject intermine/imcljs "0.1.27"
   :description "imcljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -11,13 +11,14 @@
                  [org.clojure/clojurescript "1.9.671"]
                  [org.clojure/core.async "0.3.443"]
                  [cljs-http "0.1.42"]
-                 [clj-http "3.6.0"]]
+                 [clj-http "3.6.0"]
+                 [cheshire "5.7.1"]]
 
   :plugins [[lein-figwheel "0.5.8"]
             [lein-cljsbuild "1.1.6" :exclusions [[org.clojure/clojure]]]
             [lein-doo "0.1.7"]]
 
-  :source-paths ["src/cljc" "src/cljs"]
+  :source-paths ["src/cljc" "src/cljs" "src/clj"]
 
   :figwheel {:server-port 5003
              :reload-clj-files {:clj true :cljc true}}

--- a/src/clj/imcljs/internal/io.clj
+++ b/src/clj/imcljs/internal/io.clj
@@ -6,7 +6,8 @@
                  :post client/post
                  :delete client/delete})
 
-(def default-options {:as :json})
+(def default-options {:as :json
+                      :throw-exceptions false})
 
 (def username-password (juxt :username :password))
 

--- a/src/clj/imcljs/internal/io.clj
+++ b/src/clj/imcljs/internal/io.clj
@@ -1,0 +1,56 @@
+(ns imcljs.internal.io
+  (:require [clojure.walk :as walk]
+            [clj-http.client :as client]
+            [imcljs.internal.defaults :refer [url]]))
+
+(def method-map {:get client/get
+                 :post client/post
+                 :delete client/delete})
+
+(def default-options {:as :json})
+
+(def username-password (juxt :username :password))
+
+(defn wrap-defaults
+  ([] (wrap-defaults {}))
+  ([m] (merge default-options m)))
+
+(defn basic-auth-xform
+  "Transform a :basic-auth username/password map into a vec"
+  [options]
+  (if (contains? options :basic-auth)
+    (update options :basic-auth username-password)
+    options))
+
+(defn xform-options
+  "Apply all transformations to options map"
+  [options]
+  (-> options
+      wrap-defaults
+      basic-auth-xform))
+
+; If we have a transform function (such as :token) then extract
+; that value from the body if the request was successful
+(defn parse-response
+  "Perform a transformation function (if present) on a successful HTTP request"
+  [xform response]
+  (if xform
+    (if (<= 200 (:status response) 300)
+      (xform (:body response))
+      response)
+    response))
+
+; Perform an HTTP request
+(defn request
+  [method path {:keys [root token model]} options & [xform]]
+  (let [http-fn (get method-map method)]
+    (parse-response xform (http-fn (url root path) (xform-options options)))))
+
+; We're using a multimethod with just one default method because clj-http
+; seems to handle parameters generically regardless of protocol.
+; However, cljs-http and therefore uses a multimethod to wrap parameters appropriately
+(defmulti restful (fn [method & args] method))
+
+(defmethod restful :default [method path service options & [xform]]
+  (request method path service options xform))
+

--- a/src/clj/imcljs/internal/io.clj
+++ b/src/clj/imcljs/internal/io.clj
@@ -1,6 +1,5 @@
 (ns imcljs.internal.io
-  (:require [clojure.walk :as walk]
-            [clj-http.client :as client]
+  (:require [clj-http.client :as client]
             [imcljs.internal.defaults :refer [url]]))
 
 (def method-map {:get client/get

--- a/src/cljc/imcljs/auth.cljc
+++ b/src/cljc/imcljs/auth.cljc
@@ -7,7 +7,7 @@
 (defn basic-auth
   "Given a username and a password return an API token"
   [service username password]
-  (restful :basic-auth "/user/token" service {:username username :password password} :token))
+  (restful :get "/user/token" service {:basic-auth {:username username :password password}} :token))
 
 (defn who-am-i?
   "Given a token return user information"

--- a/src/cljs/imcljs/internal/io.cljs
+++ b/src/cljs/imcljs/internal/io.cljs
@@ -1,11 +1,10 @@
 (ns imcljs.internal.io
-
-  (:require #?(:cljs [cljs-http.client :refer [post get delete]]
-               :clj [clj-http.client :refer [post get delete]])
-                    [imcljs.internal.utils :refer [scrub-url]]
-                    [imcljs.internal.defaults :refer [url wrap-get-defaults wrap-request-defaults
-                                                      wrap-post-defaults wrap-auth wrap-accept
-                                                      wrap-delete-defaults]]))
+  (:require [cljs-http.client :refer [post get delete]]
+            [imcljs.internal.utils :refer [scrub-url]]
+            [imcljs.internal.defaults
+             :refer [url wrap-get-defaults wrap-request-defaults
+                     wrap-post-defaults wrap-auth wrap-accept
+                     wrap-delete-defaults transform-if-successful]]))
 
 ;(defn body-
 ;  "Parses the body of the web service response.
@@ -52,10 +51,13 @@
 (defn basic-auth-wrapper-
   "Returns the results of queries as table rows."
   [path {:keys [root token model]} options & [xform]]
-  (get (url root path)
+  ; clj-http expects basic-auth params as [username password
+  ; cljs-http expects basic-auth params as {:username username :password password}
+  (let [basic-auth-params options]
+    (get (url root path)
        (-> {} ; Blank request map
            (wrap-request-defaults xform) ; Add defaults such as with-credentials false?
-           (assoc :basic-auth options))))
+           (assoc :basic-auth basic-auth-params)))))
 
 (defmulti restful (fn [method & args] method))
 


### PR DESCRIPTION
The clj-http and cljs-http libraries are similar, however they differ in how they handle coercion, transformation channels, and parameters. By moving just the HTTP methods to their own clj and cljs namespaces we can fine tune the wrapping functions without relying on reader conditionals in the cljc files.