### PR TITLE
Add query support in the JVM along with a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,17 @@ Most result-fetching functions require that the `:model` key be present in their
 (go (log (<! (fetch/row-count flymine my-query))))
 
 ```
+
+## Development
+
+### Running tests
+
+To run tests in the browser:
+```bash
+lein doo default
+```
+
+To run tests in the JVM:
+```bash
+lein test
+```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/imcljs "0.6.0-SNAPSHOT"
+(defproject org.intermine/imcljs "0.6.0"
   :description "imcljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -19,7 +19,7 @@
             [lein-cljsbuild "1.1.6" :exclusions [[org.clojure/clojure]]]
             [lein-doo "0.1.7"]]
 
-  :source-paths ["src/cljc" "src/cljs" "src/clj"]
+  :source-paths ["src/cljc" "src/cljs" "src/clj" "test/clj" "test/cljs"]
 
   :figwheel {:server-port 5003
              :reload-clj-files {:clj true :cljc true}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/imcljs "0.5.1"
+(defproject org.intermine/imcljs "0.6.0-SNAPSHOT"
   :description "imcljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/imcljs "0.5.0"
+(defproject org.intermine/imcljs "0.5.1"
   :description "imcljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -173,6 +173,6 @@
            service
            (-> options
                ; Enforce JSON response so that the :code function below works
-               {:format "json"}
+               (merge {:format "json"})
                (update :query (partial im-query/->xml model)))
            :code))

--- a/test/clj/imcljs/core_test.clj
+++ b/test/clj/imcljs/core_test.clj
@@ -1,0 +1,18 @@
+(ns imcljs.core-test
+  (:require [clojure.test :refer :all]
+            [imcljs.fetch :as fetch]))
+
+(defn run-query []
+  (let [model (fetch/model {:root "www.flymine.org/flymine"})]
+    (:body (fetch/rows {:root "www.flymine.org/flymine" :model model}
+                       {:from "Gene"
+                        :select ["id"]
+                        :where [{:path "symbol" :op "=" :value "zen"}]}))))
+
+(deftest a-test
+  (testing "JVM can perform a POST request"
+    (let [{:keys [results statusCode]} (run-query)]
+      (and
+        (is (= 200 statusCode)
+            (> 0 (count results)))))))
+


### PR DESCRIPTION
This branch adds the following:

* A mulimethod that allows POST requests (queries) to be made when using imcljs in the JVM
* JVM test for running a query 
* Instructions for running tests in README.md