### PR TITLE
Informative assertions for restful arguments

### DIFF
--- a/src/clj/imcljs/internal/io.clj
+++ b/src/clj/imcljs/internal/io.clj
@@ -4,7 +4,8 @@
             [imcljs.query :as q]
             [imcljs.internal.defaults :refer [url wrap-request-defaults
                                               wrap-post-defaults
-                                              wrap-auth]]))
+                                              wrap-auth]]
+            [imcljs.internal.utils :refer [assert-args]]))
 
 (def method-map {:get client/get
                  :post client/post
@@ -60,8 +61,8 @@
 (defn wrap-basic-auth [request]
   (if (contains? request :basic-auth)
     (update request :basic-auth (juxt :username :password))
-    request)
-  )
+    request))
+
 
 (defn get-body-wrapper-
   [path {:keys [root token model]} options & [xform]]
@@ -99,7 +100,10 @@
 ; We're using a multimethod with just one default method because clj-http
 ; seems to handle parameters generically regardless of protocol.
 ; However, cljs-http and therefore uses a multimethod to wrap parameters appropriately
-(defmulti restful (fn [method & args] method))
+(defmulti restful
+  (fn [method & args]
+    (apply assert-args method args)
+    method))
 
 (defmethod restful :raw [_ method path {:keys [root token model] :as service} request & [xform]]
   (let [http-fn (get method-map method)]

--- a/src/cljc/imcljs/internal/utils.cljc
+++ b/src/cljc/imcljs/internal/utils.cljc
@@ -43,3 +43,16 @@
       (recur (conj coll (<! (first chans)))
              (rest chans))
       coll)))
+
+(defn assert-args
+  [method & args]
+  (let [[path service options & [xform]] (cond->> args
+                                           (= method :raw) (drop 1))]
+    (assert ((every-pred string? not-empty) path)
+            "path should be a non-empty string.")
+    (assert ((every-pred string? not-empty) (:root service))
+            "service should always have a root URL.")
+    (assert ((some-fn map? nil?) options)
+            "options should be a map if non-nil.")
+    (assert ((some-fn ifn? nil?) xform)
+            "xform should be a callable function if non-nil.")))

--- a/src/cljs/imcljs/internal/io.cljs
+++ b/src/cljs/imcljs/internal/io.cljs
@@ -1,6 +1,6 @@
 (ns imcljs.internal.io
   (:require [cljs-http.client :refer [post get delete]]
-            [imcljs.internal.utils :refer [scrub-url]]
+            [imcljs.internal.utils :refer [assert-args]]
             [imcljs.internal.defaults
              :refer [url wrap-get-defaults wrap-request-defaults
                      wrap-post-defaults wrap-auth wrap-accept
@@ -77,7 +77,10 @@
              (wrap-request-defaults xform) ; Add defaults such as with-credentials false?
              (assoc :basic-auth basic-auth-params)))))
 
-(defmulti restful (fn [method & args] method))
+(defmulti restful
+  (fn [method & args]
+    (apply assert-args method args)
+    method))
 
 ;(defmethod restful :raw [method path {:keys [root token model] :as service} request & [xform]]
 ;  (let [http-fn (case method :get get :post post :delete delete)]

--- a/test/cljs/imcljs/runner.cljs
+++ b/test/cljs/imcljs/runner.cljs
@@ -6,6 +6,7 @@
             [imcljs.list-test]
             [imcljs.assets-test]
             [imcljs.registry-test]
-            [imcljs.auth-test]))
+            [imcljs.auth-test]
+            [imcljs.utils-test]))
 
-(doo-tests 'imcljs.path-test 'imcljs.query-test 'imcljs.list-test 'imcljs.assets-test 'imcljs.registry-test 'imcljs.auth-test)
+(doo-tests 'imcljs.path-test 'imcljs.query-test 'imcljs.list-test 'imcljs.assets-test 'imcljs.registry-test 'imcljs.auth-test 'imcljs.utils-test)

--- a/test/cljs/imcljs/utils_test.cljs
+++ b/test/cljs/imcljs/utils_test.cljs
@@ -1,0 +1,18 @@
+(ns imcljs.utils-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [imcljs.internal.io :refer [restful]]))
+
+(def service {:root "www.flymine.org/query"
+              :model {:name "genomic"}})
+
+(def args [:get "/lists" service {:name "banana"} (comp first :lists)])
+
+(deftest assert-args
+  (testing "throws on empty path string"
+    (is (thrown-with-msg? js/Error #"path" (apply restful (assoc args 1 "")))))
+  (testing "throws on missing root URL"
+    (is (thrown-with-msg? js/Error #"root" (apply restful (update args 2 assoc :root nil)))))
+  (testing "throws when options is unexpected type"
+    (is (thrown-with-msg? js/Error #"options" (apply restful (update args 3 seq)))))
+  (testing "throws when xform is unexpected type"
+    (is (thrown-with-msg? js/Error #"xform" (apply restful (assoc args 4 0))))))


### PR DESCRIPTION
Resolves #34. This gives useful error messages when request data is
missing or invalid, instead of a random failing Clojure function
throwing.