### PR TITLE
Remove get-plain in favour of restful :raw for fetch/registry

### DIFF
--- a/src/clj/imcljs/internal/io.clj
+++ b/src/clj/imcljs/internal/io.clj
@@ -13,12 +13,6 @@
 (def default-options {:as :json})
 ;:throw-exceptions false
 
-(defn get-plain
-  "most methods assume communication with an InterMine.
-   This method allows comms with any server"
-  [url options]
-  (client/get url options))
-
 
 (def username-password (juxt :username :password))
 

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -1,6 +1,6 @@
 (ns imcljs.fetch
   #?(:cljs (:require-macros [cljs.core.async.macros :refer [go go-loop]]))
-  (:require [imcljs.internal.io :refer [restful get-plain]]
+  (:require [imcljs.internal.io :refer [restful]]
     [imcljs.query :as im-query]
     #?(:cljs [cljs.core.async :refer [<! >! chan timeout]]
        :clj
@@ -89,7 +89,7 @@
   [service & [options]]
   ;;remove any old tokens passed in as they'll cause an auth failure
   (let [token-free-service (dissoc service :token)]
-  (restful :get "/session" token-free-service options :token)))
+   (restful :get "/session" token-free-service options :token)))
 
 ; Widgets
 
@@ -190,8 +190,7 @@
   "Returns list of InterMines from the InterMine registry. dev-mines? needs to
    be set to true if you want to return non-prod mines, or otherwise set to false"
   [dev-mines?]
-  (get-plain "http://registry.intermine.org/service/instances"
-             (if dev-mines?
-               {:with-credentials? false
-                :query-params {:mines "all"}}
-               {:with-credentials? false})))
+  (restful :raw :get "/instances"
+           {:root "http://registry.intermine.org/service"}
+           (when dev-mines? {:query-params {:mines "all"}})
+           :instances))

--- a/src/cljs/imcljs/internal/io.cljs
+++ b/src/cljs/imcljs/internal/io.cljs
@@ -17,12 +17,6 @@
 ;      ;(close! request-chan)
 ;      (if xform (xform response) response))))
 
-(defn get-plain
-  "most methods assume communication with an InterMine.
-   This method allows comms with any server"
-  [url options]
-  (get url options))
-
 (defn post-body-wrapper-
   "Returns the results of queries as table rows."
   [path {:keys [root token model]} options & [xform]]

--- a/test/cljs/imcljs/registry_test.cljs
+++ b/test/cljs/imcljs/registry_test.cljs
@@ -14,6 +14,6 @@
                (let [prod (<! prod-mines)
                      dev (<! dev-and-prod-mines)]
                  (is (<
-                      (count (:instances (:body prod)))
-                      (count (:instances (:body dev)))))
+                      (count prod)
+                      (count dev)))
                  (done)))))))


### PR DESCRIPTION
Maybe a bit cheeky/nitpicky PR, but we can go a bit cleaner by using `restful :raw` instead of `get-plain`.

The resulting function call is identical in clojurescript, but in clojure `{:as :json}` will be added to the option/request map instead of `{:with-credentials? false}` (due to the `:raw` method in the CLJ source not calling `wrap-request-defaults` like the CLJS source does). It didn't seem to make a difference to the result when I tested in the REPL.

Note that this is kind of a breaking change, as the presence of xforms in `restful :raw` removes the need to `(get-in res [:body :instances])`, so a small change needs to be done in bluegenes when we update this package.