### PR TITLE
Use https by default instead of http

### DIFF
--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -198,6 +198,6 @@
    be set to true if you want to return non-prod mines, or otherwise set to false"
   [dev-mines?]
   (restful :raw :get "/instances"
-           {:root "http://registry.intermine.org/service"}
+           {:root "https://registry.intermine.org/service"}
            (when dev-mines? {:query-params {:mines "all"}})
            :instances))

--- a/src/cljc/imcljs/internal/utils.cljc
+++ b/src/cljc/imcljs/internal/utils.cljc
@@ -21,7 +21,7 @@
   "Ensures that a url starts with an http protocol and ends with /service"
   [url]
   (cond->> url
-    (missing-http?- url) (str "http://")
+    (missing-http?- url) (str "https://")
     (missing-service?- url) (append- "/service")))
 
 (defn copy-list-query


### PR DESCRIPTION
imcljs needed some small changes to work with bluegenes running in HTTPS.
I'll soon create a PR in bluegenes where you can test this (by running `lein install` in imcljs after pulling this branch).