### PR TITLE
Handle errors in resolve-identifiers

### DIFF
--- a/src/cljc/imcljs/internal/defaults.cljc
+++ b/src/cljc/imcljs/internal/defaults.cljc
@@ -29,8 +29,9 @@
       (-> request :body xform))))
 
 (defn wrap-request-defaults [m & [xform]]
-  (assoc m :with-credentials? false
-         :channel (chan 1 (map (if xform (transform-if-successful xform) :body)))))
+  (assoc m
+         :with-credentials? false
+         :channel (chan 1 (map (transform-if-successful (or xform identity))))))
 
 (defn wrap-post-defaults [request options & [model]]
   (if options


### PR DESCRIPTION
This PR adds error handling to `fetch/resolve-identifiers`. Resolves #19.

In addition, it fixes some other minor bugs:
- wrap-request-defaults: not specifying an xform would cause :body to be getted on an erroneous request. 
- fetch-id-resolution-job-status not working on Clojure due
to missing argument (JS doesn't care about this)