### PR TITLE
Improve efficiency and documentation of unique-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ imcljs returns channels so you'll also want to include core.async
 With the exception of the fetch/registry function, all imcljs functions expect a map as their first parameter containing a mandatory `:root` key and two semi-optional keys, `:token` and `:model`.
 
 ```clj
-(def flymine {:root  "www.flymine.org/query"
+(def flymine {:root  "https://www.flymine.org/flymine"
               :token nil ; Optional parameter for authentication
               :model "genomic" ; Required by some functions, such as executing a query
               })

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -54,16 +54,16 @@
   values, so we avoid sending the massive request here instead."
   [service query path & [limit]]
   (let [return-chan (chan)
-        <!rows-size #(<! (rows service query {:summaryPath path :size % :format "jsonrows"}))]
+        rows-size #(rows service query {:summaryPath path :size % :format "jsonrows"})]
     (go
       ;; We send an initial size=1 request to check how many values there are.
-      (let [{unique-count :uniqueValues :as res} (<!rows-size 1)]
+      (let [{unique-count :uniqueValues :as res} (<! (rows-size 1))]
         (cond
           ;; If there's only 1 value, we simply return our initial response.
           (= unique-count 1)           (>! return-chan res)
           ;; If there's more, we request the rest of them...
           (or (not limit)
-              (<= unique-count limit)) (>! return-chan (<!rows-size limit))
+              (<= unique-count limit)) (>! return-chan (<! (rows-size limit)))
           ;; ...except in the case where there are more than our limit.
           :else                        (>! return-chan false))))
     return-chan))

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -49,14 +49,23 @@
 
 (defn unique-values
   "Fetches unique values for a path within a query. Providing a limit shortcircuits the request
-  and returns false if the unique values exceed the limit"
+  and returns false if the unique values exceed the limit. This is primarily for the column
+  summary in im-tables-3, where we don't want to summarize columns with more than limit=1000
+  values, so we avoid sending the massive request here instead."
   [service query path & [limit]]
-  (let [return-chan (chan)]
+  (let [return-chan (chan)
+        <!rows-size #(<! (rows service query {:summaryPath path :size % :format "jsonrows"}))]
     (go
-      (let [{unique-count :uniqueValues} (<! (rows service query {:summaryPath path :size 1 :format "jsonrows"}))]
-        (if (or (not limit) (<= unique-count limit))
-          (>! return-chan (<! (rows service query {:summaryPath path :size limit :format "jsonrows"})))
-          (>! return-chan false))))
+      ;; We send an initial size=1 request to check how many values there are.
+      (let [{unique-count :uniqueValues :as res} (<!rows-size 1)]
+        (cond
+          ;; If there's only 1 value, we simply return our initial response.
+          (= unique-count 1)           (>! return-chan res)
+          ;; If there's more, we request the rest of them...
+          (or (not limit)
+              (<= unique-count limit)) (>! return-chan (<!rows-size limit))
+          ;; ...except in the case where there are more than our limit.
+          :else                        (>! return-chan false))))
     return-chan))
 
 ; Assets

--- a/test/cljs/imcljs/assets_test.cljs
+++ b/test/cljs/imcljs/assets_test.cljs
@@ -4,7 +4,7 @@
             [cljs.core.async :refer [<!]]
             [imcljs.fetch :as fetch]))
 
-(def service {:root "www.flymine.org/query"
+(def service {:root "https://www.flymine.org/flymine"
               :model {:name "genomic"}})
 
 (deftest class-keys

--- a/test/cljs/imcljs/auth_test.cljs
+++ b/test/cljs/imcljs/auth_test.cljs
@@ -4,7 +4,7 @@
             [cljs.core.async :refer [<!]]
             [imcljs.fetch :as fetch]))
 
-(def service {:root "www.flymine.org/query"
+(def service {:root "https://www.flymine.org/flymine"
               :model {:name "genomic"}
               ;;imcljs should cope with an expired token just fine
               :token "THIS_TOKEN_IS_EXPIRED"})

--- a/test/cljs/imcljs/core_test.cljs
+++ b/test/cljs/imcljs/core_test.cljs
@@ -4,7 +4,7 @@
             [cljs.core.async :refer [<!]]
             [imcljs.fetch :as fetch]))
 
-(def flymine {:root  "www.flymine.org/query"
+(def flymine {:root  "https://www.flymine.org/flymine"
               :model {:name "genomic"}})
 
 (deftest templates

--- a/test/cljs/imcljs/list_test.cljs
+++ b/test/cljs/imcljs/list_test.cljs
@@ -7,7 +7,7 @@
             [imcljs.save :as save]
             [imcljs.internal.utils :refer [<<!]]))
 
-(def service {:root "www.flymine.org/query"
+(def service {:root "https://www.flymine.org/flymine"
               :model {:name "genomic"}})
 
 (def flymine-query {:from "Gene"

--- a/test/cljs/imcljs/path_test.cljs
+++ b/test/cljs/imcljs/path_test.cljs
@@ -5,7 +5,7 @@
             [imcljs.path :as path]
             [imcljs.fetch :as fetch]))
 
-(def service {:root  "www.flymine.org/query"
+(def service {:root  "https://www.flymine.org/flymine"
               :model {:name "genomic"}})
 
 (deftest walk-subclass

--- a/test/cljs/imcljs/query_test.cljs
+++ b/test/cljs/imcljs/query_test.cljs
@@ -6,7 +6,7 @@
             [imcljs.fetch :as fetch]
             [imcljs.query :as query]))
 
-(def service {:root "www.flymine.org/query"
+(def service {:root "https://www.flymine.org/flymine"
               :model {:name "genomic"}})
 
 (def normal-query {:from "Gene"

--- a/test/cljs/imcljs/utils_test.cljs
+++ b/test/cljs/imcljs/utils_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer-macros [deftest testing is]]
             [imcljs.internal.io :refer [restful]]))
 
-(def service {:root "www.flymine.org/query"
+(def service {:root "https://www.flymine.org/flymine"
               :model {:name "genomic"}})
 
 (def args [:get "/lists" service {:name "banana"} (comp first :lists)])


### PR DESCRIPTION
I was scratching my head over the logic in `unique-values` for a long time, until I found out that im-tables-3 uses it for its column summaries, where it makes no sense to create a summary for something with more than 1000 values.

This PR improves the documentation of the function, in addition to avoid doing one extra HTTP request when uniqueValues=1, as in that case we already have all the values with a size=1 request and there's no point in sending a new one.

Can be tested by using this with Bluegenes and mousing over the top **Sequence** im-table for *eve*. There should be one request less with this PR. [=