### PR TITLE
Exclude clojure class and class? fns

### DIFF
--- a/src/cljc/imcljs/path.cljc
+++ b/src/cljc/imcljs/path.cljc
@@ -1,4 +1,5 @@
 (ns imcljs.path
+  (:refer-clojure :exclude [class class?])
   (:require [imcljs.internal.utils :refer [does-not-contain?]]
             [clojure.string :refer [split join]]))
 


### PR DESCRIPTION
fixes #27 

Excludes `class` and `class?` functions from ns, prevents compiler warnings. 