### PR TITLE
Support subclasses by passing type-constraints with model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 before_script:
   # Use a newer version of Python
   - pyenv versions
-  - pyenv global 3.6
+  - pyenv global 3.6.7
   # Setup biotestmine to test against
   - pip3 install intermine-boot
   - intermine_boot start local --build-im --im-branch bluegenes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0 (2020-10-06)
+
+- Support subclasses by passing type-constraints with model [#51](https://github.com/intermine/imcljs/pull/51)
+    - Enables `imcljs.path/walk` to traverse subclasses specified via type constraints, and enables other functions dependent on it to handle subclasses correctly
+- Do not add constraint code to type constraints when sterilizing query [#51](https://github.com/intermine/imcljs/pull/51)
+
 ## 1.1.0 (2020-02-20)
 
 - Support new web services [#42](https://github.com/intermine/imcljs/pull/42)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/imcljs "1.1.0"
+(defproject org.intermine/imcljs "1.2.0"
   :description "imcljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/cljc/imcljs/path.cljc
+++ b/src/cljc/imcljs/path.cljc
@@ -66,47 +66,70 @@
        (filter identity)
        first))
 
+(defn- walk-rec
+  [model [class-kw & [path & remaining]] trail curr-path path->subclass]
+  (let [class-kw (get path->subclass curr-path class-kw)
+        cv (class-value model class-kw path)
+        reference (:referencedType cv)]
+    (if remaining
+      (when reference
+        (recur model
+               (cons (keyword reference) remaining)
+               (conj trail (get-in model [:classes class-kw]))
+               (conj curr-path path)
+               path->subclass))
+      (conj trail (get-in model [:classes class-kw])
+            (if reference
+              (get-in model [:classes (keyword reference)])
+              cv)))))
+
 (defn walk
   "Return a vector representing each part of path.
   If any part of the path is unresolvable then a nil is returned.
   (walk im-model `Gene.organism.shortName`)
   => [{:name `Gene`, :collections {...}, :attributes {...}}
       {:name `Organism`, :collections {...} :attributes {...}
-      {:name `shortName`, :type `java.lang.String`}]"
-  ([model path]
-   (let [p (if (string? path) (split-path path) (map keyword path))]
-     (if (= 1 (count p))
-       [(get-in model [:classes (first p)])]
-       (walk model p []))))
-  ([model [class-kw & [path & remaining]] trail]
-   (let [cv (class-value model class-kw path)]
-     (if remaining
-       (cond
-         (contains? cv :referencedType)
-         (recur model
-                (cons (keyword (:referencedType cv)) remaining)
-                (conj trail (get-in model [:classes class-kw]))))
-       (conj trail (get-in model [:classes class-kw])
-             (if (contains? cv :referencedType)
-               (get-in model [:classes (keyword (:referencedType cv))])
-               cv))))))
+      {:name `shortName`, :type `java.lang.String`}]
+  If the path traverses a subclass, you'll need to add a `:type-constraints`
+  key to `model` with a value like
+      [{:path `Gene.interactions.participant2`, :type `Gene`}]
+  for the path to be resolvable.
+      (walk im-model-with-type-constraints
+       `Gene.interactions.participant2.proteinAtlasExpression.tissue.name`)"
+  [model path]
+  (let [p (if (string? path) (split-path path) (map keyword path))]
+    (if (= 1 (count p))
+      [(get-in model [:classes (first p)])]
+      (walk-rec model p [] [(first p)]
+                (->> (:type-constraints model)
+                     (filter #(contains? % :type)) ; In case there are other constraints there.
+                     (reduce (fn [m {:keys [path type]}]
+                               (assoc m (split-path path) (keyword type)))
+                             {}))))))
+
 (defn data-type
   "Return the java type of a path representing an attribute.
   (attribute-type im-model `Gene.organism.shortName`)
-  => java.lang.String"
+  => java.lang.String
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (:type (last (walk model path))))
 
 (defn class
   "Returns the class represented by the path.
   (class im-model `Gene.homologues.homologue.symbol`)
-  => :Gene"
+  => :Gene
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (let [l (last (take-while #(does-not-contain? % :type) (walk model path)))]
     (keyword (or (:referencedType l) (keyword (:name l))))))
 
 (defn relationships
-  "Returns all relationships (references and collections) for a given string path."
+  "Returns all relationships (references and collections) for a given string path.
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (apply merge (map (get-in model [:classes (class model path)]) [:references :collections])))
 
@@ -121,7 +144,7 @@
           (clojure.string/replace #"^." #(clojure.string/upper-case %))))
 
 (defn display-name
-  "Returns a vector of friendly names representing the path
+  "Returns a vector of friendly names representing the path.
   ; TODO make this work with subclasses"
   ([model path]
    (let [p (if (string? path) (split-path path) path)]
@@ -137,7 +160,9 @@
          collected+)))))
 
 (defn attributes
-  "Returns all attributes for a given string path."
+  "Returns all attributes for a given string path.
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (apply merge (map (get-in model [:classes (class model path)]) [:attributes])))
 
@@ -146,7 +171,9 @@
   (class im-model `Gene.diseases`)
   => true
   (class im-model `Gene.diseases.name`)
-  => false"
+  => false
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (let [walked (walk model path)]
     (not (contains? (last walked) :type))))
@@ -154,7 +181,9 @@
 (defn trim-to-last-class
   "Returns a path string trimmed to the last class
   (trim-to-last-class im-model `Gene.homologues.homologue.symbol`)
-  => Gene.homologues.homologue"
+  => Gene.homologues.homologue
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (let [done (take-while #(does-not-contain? % :type) (walk model path))]
     (join-path (take (count done) (split-path path)))))
@@ -162,7 +191,9 @@
 (defn adjust-path-to-last-class
   "Returns a path adjusted to its last class
   (adjust-path-to-last-class im-model `Gene.organism.name`)
-  => Organism.name"
+  => Organism.name
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (let [attribute? (not (class? model path))
         walked     (reverse (walk model path))]
@@ -171,19 +202,27 @@
       (str (:name (nth walked 0))))))
 
 (defn friendly
-  "Returns a path as a strong"
+  "Returns a path as a strong
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   ([model path & [exclude-root?]]
    (reduce
     (fn [total next]
       (str total (if total " > ") (or (:displayName next) (:name next))))
     nil
-    (if exclude-root? (rest (walk model path)) (walk model path)))))
+    (if exclude-root?
+      (rest (walk model path))
+      (walk model path)))))
 
 (defn one-of? [col value]
   (some? (some #{value} col)))
 
 (defn subclasses
-  "Returns subclasses of the class"
+  "Returns direct subclasses of the class.
+  Tip: To get descendant subclasses, you will need to create a graph out of all
+  the classes' extends key, which is costly and outside the scope of imcljs.
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `walk` for more information)."
   [model path]
   (let [path-class (class model path)]
     (->> model

--- a/src/cljc/imcljs/query.cljc
+++ b/src/cljc/imcljs/query.cljc
@@ -89,8 +89,11 @@
   (if (contains? query :where)
     (update query :where
             (fn [constraints]
-              (reduce (fn [total {:keys [code] :as constraint}]
-                        (if (some? code)
+              (reduce (fn [total {:keys [code type] :as constraint}]
+                        (if (or (some? code)
+                                ;; Type (aka subclass) constraints may not
+                                ;; participate in the constraint logic.
+                                (some? type))
                           (conj total constraint)
                           (let [existing-codes      (set (remove nil? (concat (map :code constraints) (map :code total))))
                                 next-available-code (first (filter (complement blank?) (difference alphabet existing-codes)))]

--- a/src/cljc/imcljs/query.cljc
+++ b/src/cljc/imcljs/query.cljc
@@ -153,7 +153,9 @@
   "Deconstructs a query by its views and groups them by class.
   (deconstruct-by-class model query)
   {:Gene {Gene.homologues.homologue {:from Gene :select [Gene.homologues.homologue.id] :where [...]}
-         {Gene {:from Gene :select [Gene.id] :where [...]}}}"
+         {Gene {:from Gene :select [Gene.id] :where [...]}}}
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `imcljs.path/walk` for more information)."
   [model query]
   (let [query (sterilize-query query)]
     (reduce (fn [path-map next-path]
@@ -164,7 +166,9 @@
 
 (defn group-views-by-class
   "Group the views of a query by their Class and provide a query
-  to retrieve just that column of data"
+  to retrieve just that column of data.
+  Make sure to add :type-constraints to the model if the path traverses a subclass
+  (see docstring of `imcljs.path/walk` for more information)."
   [model query]
   (let [query (sterilize-query query)]
     (reduce (fn [path-map next-path]

--- a/test/cljs/imcljs/path_test.cljs
+++ b/test/cljs/imcljs/path_test.cljs
@@ -33,6 +33,14 @@
                                               {:path "Gene.childFeatures.CDSs.transcript" :type "TRNA"}])]
           (let [walked (path/walk model "Gene.childFeatures.CDSs.transcript.name")]
             (is (= (map :name walked) '("Gene" "MRNA" "CDS" "TRNA" "name")))
+            (done))))))
+  (testing "Should walk subclass even if it's the last part of the path"
+    (async done
+      (go
+        (let [model (assoc (<! (fetch/model service))
+                           :type-constraints [{:path "Gene.childFeatures" :type "MRNA"}])]
+          (let [walked (path/walk model "Gene.childFeatures")]
+            (is (= (map :name walked) '("Gene" "MRNA")))
             (done)))))))
 
 (deftest walk-root

--- a/test/cljs/imcljs/path_test.cljs
+++ b/test/cljs/imcljs/path_test.cljs
@@ -24,6 +24,17 @@
             (is (= (map :name walked) '("Gene" "Protein" "Gene" "OntologyAnnotation" "OntologyTerm" "name")))
             (done)))))))
 
+(deftest walk-subclasses-with-type-constraints
+  (testing "Should be able to walk a path with multiple subclasses requiring type constraints and return parts of the model"
+    (async done
+      (go
+        (let [model (assoc (<! (fetch/model service))
+                           :type-constraints [{:path "Gene.childFeatures" :type "CDS"}
+                                              {:path "Gene.childFeatures.interactions.participant2" :type "Gene"}])]
+          (let [walked (path/walk model "Gene.childFeatures.interactions.participant2.proteinAtlasExpression.level")]
+            (is (= (map :name walked) '("Gene" "CDS" "Interaction" "Gene" "ProteinAtlasExpression" "level")))
+            (done)))))))
+
 (deftest walk-root
   (testing "Should be able to walk a path that is a single root and return parts of the model"
     (async done

--- a/test/cljs/imcljs/path_test.cljs
+++ b/test/cljs/imcljs/path_test.cljs
@@ -29,10 +29,10 @@
     (async done
       (go
         (let [model (assoc (<! (fetch/model service))
-                           :type-constraints [{:path "Gene.childFeatures" :type "CDS"}
-                                              {:path "Gene.childFeatures.interactions.participant2" :type "Gene"}])]
-          (let [walked (path/walk model "Gene.childFeatures.interactions.participant2.proteinAtlasExpression.level")]
-            (is (= (map :name walked) '("Gene" "CDS" "Interaction" "Gene" "ProteinAtlasExpression" "level")))
+                           :type-constraints [{:path "Gene.childFeatures" :type "MRNA"}
+                                              {:path "Gene.childFeatures.CDSs.transcript" :type "TRNA"}])]
+          (let [walked (path/walk model "Gene.childFeatures.CDSs.transcript.name")]
+            (is (= (map :name walked) '("Gene" "MRNA" "CDS" "TRNA" "name")))
             (done)))))))
 
 (deftest walk-root


### PR DESCRIPTION
There were two alternatives to passing type-constraints to `imcljs.path/walk` so that all functions would work with subclass constraints:
- Pass as optional argument, which would need to be added to every function dependent (directly or indirectly) on `walk`
- Pass assoc'ed to model

The latter approach was chosen as it would require much less refactoring in Bluegenes, the downside being it's more subtle. Hopefully mentioning this in every docstring will be enough.

Resolves #50 by making the docstring clearer.

I will wait with merging this until I have the Bluegenes PR utilizing this ready.