### PR TITLE
More webservices and various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ Most result-fetching functions require that the `:model` key be present in their
 
 **Required dependency:** phantomjs, to run the tests in a headless javascript engine. You'll need a recent version of node installed, perhaps via [nvm](https://github.com/creationix/nvm). Once node is installed, run `npm install -g phantomjs` to install phantomjs. 
 
+**Local biotestmine:** The tests are run against a local biotestmine instance on port 9999 (can be changed in *test/cljs/imcljs/env.cljs*). If you're not familiar with building InterMine instances, we recommend using [intermine_boot](https://github.com/intermine/intermine_boot).
+
 **To run tests in the browser:**
 ```bash
 lein doo
 ```
 
-To run tests in the JVM:
+**To run tests in the JVM:**
 ```bash
 lein test
 ```

--- a/src/clj/imcljs/internal/io.clj
+++ b/src/clj/imcljs/internal/io.clj
@@ -5,7 +5,8 @@
             [imcljs.internal.defaults :refer [url wrap-request-defaults
                                               wrap-post-defaults
                                               wrap-put-defaults
-                                              wrap-auth]]
+                                              wrap-auth
+                                              wrap-get-defaults]]
             [imcljs.internal.utils :refer [assert-args]]))
 
 (def method-map {:get client/get
@@ -59,12 +60,12 @@
 (defn get-body-wrapper-
   [path {:keys [root token model]} options & [xform]]
   (parse-response xform (client/get (url root path)
-                                    (-> options ; Blank request map
+                                    (-> {} ; Blank request map
                                         ;(wrap-accept)
                                         (wrap-request-defaults xform) ; Add defaults such as with-credentials false?
+                                        (wrap-get-defaults options) ; Add query params
                                         ; If we have basic auth options then convert them from the cljs-http to clj-http format
-                                        wrap-basic-auth
-                                        ;(wrap-post-defaults options model) ; Add form params
+                                        (wrap-basic-auth)
                                         (wrap-auth token)
                                         (merge {:as :json})))))
 

--- a/src/cljc/imcljs/auth.cljc
+++ b/src/cljc/imcljs/auth.cljc
@@ -57,3 +57,22 @@
   [service deregistration-token & [options]]
   (let [params {:deregistrationToken deregistration-token}]
     (restful :delete "/user" service (merge params options))))
+
+(defn oauth2authenticator
+  "Commence authentication for logging in using OAuth 2.0 with specified
+  provider.  Will return a URL to redirect to the external login page.
+  Remember to append a `redirect_uri` parameter to the URL before redirecting.
+  This should be an endpoint which will be redirected to after signing in at
+  the third-party, passing parameters required for the `oauth2callback`.
+  Note that the redirect URL might be checked against a whitelist."
+  [service provider & [options]]
+  (let [params {:provider provider}]
+    (restful :get "/oauth2authenticator" service (merge params options) :link)))
+
+(defn oauth2callback
+  "Complete authentication for logging in using OAuth 2.0. Requires parameters
+  state and code, which are received when redirecting back from the external
+  login service in `oauth2authenticator`, in addition to provider which should
+  be identical to the one passed to `oauth2authenticator`."
+  [service & [options]]
+  (restful :get "/oauth2callback" service options))

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -164,6 +164,12 @@
   [service]
   (restful :get "/branding" service {} :properties))
 
+(defn bluegenes-properties
+  "Returns the BlueGenes-specific configs for a given mine. These are created
+  and maintained by BlueGenes, similarly to a key-value store."
+  [service & [options]]
+  (restful :get "/bluegenes-properties" service options :bluegenes-properties))
+
 
 ; ID Resolution
 

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -84,6 +84,12 @@
   [service name & [options]]
   (restful :get "/lists" service (merge {:name name} options) (comp first :lists)))
 
+(defn lists-containing
+  "Find lists on the server containing an object.
+  As a minimum, specify either :id or both of :publicId and :type."
+  [service & [options]]
+  (restful :get "/listswithobject" service options :lists))
+
 (defn model
   [service & [options]]
   (restful :get "/model" service options :model))

--- a/src/cljc/imcljs/fetch.cljc
+++ b/src/cljc/imcljs/fetch.cljc
@@ -158,6 +158,12 @@
   [service]
   (restful :get "/web-properties" service {} :web-properties))
 
+(defn branding
+  "Returns the branding details for a given mine.
+  Used to make things more personal!"
+  [service]
+  (restful :get "/branding" service {} :properties))
+
 
 ; ID Resolution
 

--- a/src/cljc/imcljs/path.cljc
+++ b/src/cljc/imcljs/path.cljc
@@ -124,12 +124,12 @@
     (if (= 1 (count p))
       [(get-in model [:classes (first p)])]
       (walk-loop model p
-        :path->subclass (->> (:type-constraints model)
-                             (filter #(contains? % :type)) ; In case there are other constraints there.
-                             (reduce (fn [m {:keys [path type]}]
-                                       (assoc m (split-path path) (keyword type)))
-                                     {}))
-        :walk-properties? walk-properties?))))
+                 :path->subclass (->> (:type-constraints model)
+                                      (filter #(contains? % :type)) ; In case there are other constraints there.
+                                      (reduce (fn [m {:keys [path type]}]
+                                                (assoc m (split-path path) (keyword type)))
+                                              {}))
+                 :walk-properties? walk-properties?))))
 
 (defn data-type
   "Return the java type of a path representing an attribute.

--- a/src/cljc/imcljs/save.cljc
+++ b/src/cljc/imcljs/save.cljc
@@ -97,3 +97,24 @@
   [service title & [options]]
   (let [params (merge {:name title} options)]
     (restful :delete "/user/queries" service params)))
+
+(defn bluegenes-properties
+  "Add a new key to the BlueGenes-specific config for a mine.
+  Requires that you are authenticated as an admin."
+  [service key value & [options]]
+  (let [params (merge {:key key :value value} options)]
+    (restful :post "/bluegenes-properties" service params)))
+
+(defn update-bluegenes-properties
+  "Update an existing key in the BlueGenes-specific config for a mine.
+  Requires that you are authenticated as an admin."
+  [service key value & [options]]
+  (let [params (merge {:key key :value value} options)]
+    (restful :put "/bluegenes-properties" service params)))
+
+(defn delete-bluegenes-properties
+  "Delete an existing key in the BlueGenes-specific config for a mine.
+  Requires that you are authenticated as an admin."
+  [service key & [options]]
+  (let [params (merge {:key key} options)]
+    (restful :delete "/bluegenes-properties" service params)))

--- a/src/cljs/imcljs/internal/io.cljs
+++ b/src/cljs/imcljs/internal/io.cljs
@@ -29,7 +29,13 @@
             (wrap-auth token)
             ; Stringify the clojure body to a JSON data structure
             ; This should still work when sending plain/text rather than application/json
-            (update :body (comp js/JSON.stringify clj->js)))))
+            (update :body (fn [body]
+                            (if (coll? body)
+                              (-> body clj->js js/JSON.stringify)
+                              ;; If the body is not a collection (usually a map), it is most likely a string.
+                              ;; We have to pass them as they are, or else the "" will get included in the body,
+                              ;; which makes it impossible to pass more than one identifier.
+                              body))))))
 
 (defn post-wrapper-
   "Returns the results of queries as table rows."

--- a/test/cljs/imcljs/bgproperties_test.cljs
+++ b/test/cljs/imcljs/bgproperties_test.cljs
@@ -1,0 +1,45 @@
+(ns imcljs.bgproperties-test
+  (:require-macros [cljs.core.async.macros :refer [go]])
+  (:require [cljs.test :refer-macros [async deftest testing is]]
+            [cljs.core.async :refer [<!]]
+            [imcljs.fetch :as fetch]
+            [imcljs.save :as save]
+            [imcljs.env :refer [service]]
+            [imcljs.auth :as auth]
+            [clojure.edn :as edn]))
+
+(def bg-key "ole.dole.doffen")
+
+(defn read-prop [value]
+  (edn/read-string value))
+
+(defn write-prop [value]
+  (pr-str value))
+
+(deftest bg-properties
+  (async done
+    (go
+      (let [login-response (<! (auth/login service "test_user@mail_account" "secret"))
+            token (get-in login-response [:output :token])
+            service (assoc service :token token)]
+        (testing "Add new key to bluegenes properties"
+          (let [value {:foo "bar"}
+                _save-value (<! (save/bluegenes-properties service bg-key (write-prop value)))
+                saved (-> (<! (fetch/bluegenes-properties service))
+                          (get (keyword bg-key))
+                          (read-prop))]
+            (is (= value saved))))
+        (testing "Update an existing key in bluegenes properties"
+          (let [value {:foo "baz"}
+                _update-value (<! (save/update-bluegenes-properties service bg-key (write-prop value)))
+                updated (-> (<! (fetch/bluegenes-properties service))
+                            (get (keyword bg-key))
+                            (read-prop))]
+            (is (= value updated))))
+        (testing "Delete an existing kkey in bluegenes properties"
+          (let [_delete-value (<! (save/delete-bluegenes-properties service bg-key))
+                deleted (-> (<! (fetch/bluegenes-properties service))
+                            (get (keyword bg-key))
+                            (read-prop))]
+            (is (nil? deleted))))
+        (done)))))

--- a/test/cljs/imcljs/runner.cljs
+++ b/test/cljs/imcljs/runner.cljs
@@ -9,6 +9,7 @@
             [imcljs.auth-test]
             [imcljs.utils-test]
             [imcljs.preferences-test]
-            [imcljs.saved-queries-test]))
+            [imcljs.saved-queries-test]
+            [imcljs.bgproperties-test]))
 
-(doo-tests 'imcljs.core-test 'imcljs.path-test 'imcljs.query-test 'imcljs.list-test 'imcljs.assets-test 'imcljs.registry-test 'imcljs.auth-test 'imcljs.utils-test 'imcljs.preferences-test 'imcljs.saved-queries-test)
+(doo-tests 'imcljs.core-test 'imcljs.path-test 'imcljs.query-test 'imcljs.list-test 'imcljs.assets-test 'imcljs.registry-test 'imcljs.auth-test 'imcljs.utils-test 'imcljs.preferences-test 'imcljs.saved-queries-test 'imcljs.bgproperties-test)


### PR DESCRIPTION
Stuff required to accommodate coming im-tables-3 and Bluegenes releases.

Includes a substantial rewrite of `imcljs.path/walk`, which used to be overly complicated and hard to extend.

Fixes #46.