### PR TITLE
Make deconstruct-by-class match im-tables behaviour

### DIFF
--- a/src/cljc/imcljs/query.cljc
+++ b/src/cljc/imcljs/query.cljc
@@ -196,6 +196,21 @@
          (apply str (map (partial map->xmlstr "constraint") (:where query)))
          "\n</query>")))
 
+(defn- substitute-constraints
+  "Inner joins are default for every class in the view, which means once
+  they're removed from the view, we need their equivalent as constraints to
+  query the same set of objects. This doesn't apply to outer joins and the only
+  selected path, which won't get added as constraints."
+  [model query select-path]
+  (let [joins (conj (set (:joins query)) select-path)]
+    (map (fn [class-path]
+           {:path (str class-path ".id")
+            :op "IS NOT NULL"})
+         (into #{}
+               (comp (map #(path/trim-to-last-class model %))
+                     (remove #(contains? joins %)))
+               (:select query)))))
+
 (defn deconstruct-by-class
   "Deconstructs a query by its views and groups them by class.
   (deconstruct-by-class model query)
@@ -204,24 +219,14 @@
   Make sure to add :type-constraints to the model if the path traverses a subclass
   (see docstring of `imcljs.path/walk` for more information)."
   [model query]
-  (let [query (sterilize-query query)
-        ;; Inner joins are default for every class in the view, which means
-        ;; once they're removed from the view, we need their equivalent as
-        ;; constraints to query the same set of objects.
-        substitute-constraints (map (fn [class-path]
-                                      {:path (str class-path ".id")
-                                       :op "IS NOT NULL"})
-                                    (into #{}
-                                          (comp (map #(path/trim-to-last-class model %))
-                                                ;; Except for outer joins, in which case we shouldn't constrain for their existence.
-                                                (remove #(contains? (set (:joins query)) %)))
-                                          (:select query)))]
+  (let [query (sterilize-query query)]
     (reduce (fn [path-map next-path]
-              (update path-map (path/class model next-path)
-                      assoc (path/trim-to-last-class model next-path)
-                      {:query (-> query
-                                  (assoc :select [(str (path/trim-to-last-class model next-path) ".id")])
-                                  (update :where into substitute-constraints))}))
+              (let [select-path (path/trim-to-last-class model next-path)]
+                (update path-map (path/class model next-path)
+                        assoc (path/trim-to-last-class model next-path)
+                        {:query (-> query
+                                    (assoc :select [(str select-path ".id")])
+                                    (update :where into (substitute-constraints model query select-path)))})))
             {} (:select query))))
 
 (defn group-views-by-class
@@ -232,10 +237,13 @@
   [model query]
   (let [query (sterilize-query query)]
     (reduce (fn [path-map next-path]
-              (update path-map (path/class model next-path)
-                      (comp vec set conj)
-                      {:path (str (path/trim-to-last-class model next-path) ".id")
-                       :type (path/class model next-path)
-                       :query (assoc query :select [(str (path/trim-to-last-class model next-path) ".id")])}))
+              (let [select-path (path/trim-to-last-class model next-path)]
+                (update path-map (path/class model next-path)
+                        (comp vec set conj)
+                        {:path (str (path/trim-to-last-class model next-path) ".id")
+                         :type (path/class model next-path)
+                         :query (-> query
+                                    (assoc :select [(str select-path ".id")])
+                                    (update :where into (substitute-constraints model query select-path)))})))
             {} (:select query))))
 

--- a/test/cljs/imcljs/query_test.cljs
+++ b/test/cljs/imcljs/query_test.cljs
@@ -48,21 +48,6 @@
       (go
         (let [model (<! (fetch/model service))]
           (let [result (query/deconstruct-by-class model normal-query)]
-            (is (= result {:Gene
-                           {"Gene.proteins.genes"
-                            {:query
-                             {:where [{:path "Gene.symbol", :value "ABRA", :op "=", :code "A"}]
-                              :from "Gene"
-                              :select ["Gene.proteins.genes.id"]}}
-                            "Gene"
-                            {:query
-                             {:where [{:path "Gene.symbol", :value "ABRA", :op "=", :code "A"}]
-                              :from "Gene"
-                              :select ["Gene.id"]}}}
-                           :Organism
-                           {"Gene.organism"
-                            {:query
-                             {:where [{:path "Gene.symbol", :value "ABRA", :op "=", :code "A"}]
-                              :from "Gene"
-                              :select ["Gene.organism.id"]}}}}))
+            (is (= result
+                   {:Gene {"Gene" {:query {:from "Gene", :select ["Gene.id"], :where [{:path "Gene.symbol", :op "=", :value "ABRA", :code "A"} {:path "Gene.organism.id", :op "IS NOT NULL"} {:path "Gene.proteins.genes.id", :op "IS NOT NULL"}]}}, "Gene.proteins.genes" {:query {:from "Gene", :select ["Gene.proteins.genes.id"], :where [{:path "Gene.symbol", :op "=", :value "ABRA", :code "A"} {:path "Gene.id", :op "IS NOT NULL"} {:path "Gene.organism.id", :op "IS NOT NULL"}]}}}, :Organism {"Gene.organism" {:query {:from "Gene", :select ["Gene.organism.id"], :where [{:path "Gene.symbol", :op "=", :value "ABRA", :code "A"} {:path "Gene.id", :op "IS NOT NULL"} {:path "Gene.proteins.genes.id", :op "IS NOT NULL"}]}}}}))
             (done)))))))


### PR DESCRIPTION
Due to how the view is overwritten by a single target class as required
by tolist WS, this leads to a differing query result set, as the views
implicitly constrain refs/colls to be present (inner join being the
default). To match this behaviour without views, we need to add IS NOT
NULL constraints for them, except in the case where the class is an
outer join, when it should not receive a substitute constraint.

This bug was found investigating https://github.com/intermine/im-tables-3/issues/129 where saving a list in im-tables-3 would lead to a different amount of items compared to im-tables (legacy webapp).